### PR TITLE
Checkmarx AI Remediation - Command_Injection

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -2,13 +2,16 @@ package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
 
 public class Cowsay {
   public static String run(String input) {
-    ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    // Use an argument list instead of a shell string to prevent command injection.
+    // ProcessBuilder with a List<String> does not invoke a shell, so shell metacharacters
+    // in 'input' are treated as literal data passed to cowsay, not as shell syntax.
+    List<String> cmd = Arrays.asList("/usr/games/cowsay", input);
+    ProcessBuilder processBuilder = new ProcessBuilder(cmd);
 
     StringBuilder output = new StringBuilder();
 
@@ -18,7 +21,7 @@ public class Cowsay {
 
       String line;
       while ((line = reader.readLine()) != null) {
-        output.append(line + "\n");
+        output.append(line).append("\n");
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/java/com/scalesec/vulnado/CowsayTest.java
+++ b/src/test/java/com/scalesec/vulnado/CowsayTest.java
@@ -1,0 +1,172 @@
+package com.scalesec.vulnado;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for Cowsay.run() verifying that command injection is no longer possible
+ * after replacing the shell-string invocation with a ProcessBuilder argument list.
+ *
+ * Because the /usr/games/cowsay binary may not be present in every CI environment,
+ * each test gracefully handles an empty/null output while still asserting that
+ * shell metacharacters are NOT interpreted as commands.
+ */
+@RunWith(JUnit4.class)
+public class CowsayTest {
+
+    /**
+     * A benign input should either produce cowsay ASCII art (if binary is present)
+     * or an empty string (if binary is absent).  It must never throw an exception
+     * and must never return null.
+     */
+    @Test
+    public void run_withBenignInput_returnsStringWithoutException() {
+        String result = Cowsay.run("hello");
+        assertNotNull("run() must never return null", result);
+    }
+
+    /**
+     * Shell metacharacters that were previously exploitable via the bash -c invocation
+     * must now be passed as literal arguments to cowsay and MUST NOT be executed.
+     *
+     * Attack pattern: injection via single-quote escape followed by a subcommand.
+     * Old code:  bash -c "/usr/games/cowsay 'hello'; <injected>"
+     * Fixed code: ProcessBuilder(["/usr/games/cowsay", "hello'; id"])  — no shell involved.
+     *
+     * We verify by checking that the output does not contain typical shell command output
+     * patterns that an injected "id" or "echo" command would produce.
+     */
+    @Test
+    public void run_withSingleQuoteInjectionAttempt_doesNotExecuteInjectedCommand() {
+        // Attempt to break out of single quotes and run an injected command
+        String maliciousInput = "' ; echo INJECTED_MARKER ; echo '";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        // The string "INJECTED_MARKER" should never appear in the output because
+        // the shell was never invoked — cowsay receives the whole string as one argument.
+        assertFalse(
+            "Shell injection via single-quote escape must not execute",
+            result.contains("INJECTED_MARKER")
+        );
+    }
+
+    /**
+     * Subshell injection attempt using $() syntax.
+     * Without a shell, $(...) is just literal text passed to cowsay.
+     */
+    @Test
+    public void run_withSubshellInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "$(echo SUBSHELL_INJECTED)";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Subshell injection $(...) must not be evaluated",
+            result.contains("SUBSHELL_INJECTED")
+        );
+    }
+
+    /**
+     * Backtick command substitution injection attempt.
+     * Without a shell, backticks are literal characters.
+     */
+    @Test
+    public void run_withBacktickInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "`echo BACKTICK_INJECTED`";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Backtick command substitution must not be evaluated",
+            result.contains("BACKTICK_INJECTED")
+        );
+    }
+
+    /**
+     * Semicolon command-chaining injection attempt.
+     */
+    @Test
+    public void run_withSemicolonInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "hello; echo SEMICOLON_INJECTED";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Semicolon command chaining must not be evaluated",
+            result.contains("SEMICOLON_INJECTED")
+        );
+    }
+
+    /**
+     * Pipe injection attempt.
+     */
+    @Test
+    public void run_withPipeInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "hello | echo PIPE_INJECTED";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Pipe injection must not be evaluated",
+            result.contains("PIPE_INJECTED")
+        );
+    }
+
+    /**
+     * Ampersand background-execution injection attempt.
+     */
+    @Test
+    public void run_withAmpersandInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "hello & echo AMPERSAND_INJECTED";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Ampersand background injection must not be evaluated",
+            result.contains("AMPERSAND_INJECTED")
+        );
+    }
+
+    /**
+     * Newline injection attempt (sometimes used to inject shell commands).
+     */
+    @Test
+    public void run_withNewlineInjectionAttempt_doesNotExecuteInjectedCommand() {
+        String maliciousInput = "hello\necho NEWLINE_INJECTED";
+        String result = Cowsay.run(maliciousInput);
+
+        assertNotNull("run() must never return null", result);
+        assertFalse(
+            "Newline injection must not be evaluated as a separate shell command",
+            result.contains("NEWLINE_INJECTED")
+        );
+    }
+
+    /**
+     * Empty input should return a non-null string without throwing.
+     */
+    @Test
+    public void run_withEmptyInput_returnsWithoutException() {
+        String result = Cowsay.run("");
+        assertNotNull("run() must never return null for empty input", result);
+    }
+
+    /**
+     * Null input should not cause a NullPointerException that propagates to callers;
+     * the method returns a string (possibly empty) or an empty string after the caught exception.
+     */
+    @Test
+    public void run_withNullInput_doesNotThrowToCallers() {
+        try {
+            String result = Cowsay.run(null);
+            // If it doesn't throw, result must be non-null (empty string from the catch block).
+            assertNotNull("run() must not return null even for null input", result);
+        } catch (Exception e) {
+            fail("run() must not propagate exceptions to callers, but threw: " + e);
+        }
+    }
+}


### PR DESCRIPTION
![Logo](https://cdn.ast.checkmarx.net/integrations/logo/Checkmarx.png)
**Checkmarx One – Remediation**

---

## Command_Injection · <img src="https://cdn.ast.checkmarx.net/integrations/severity/Critical.png" width="18" height="18" /> Critical

Triage context: <img src="https://cdn.ast.checkmarx.net/integrations/triage/reachable.png" width="16" height="16" /> **Reachable** · <img src="https://cdn.ast.checkmarx.net/integrations/triage/exploitable.png" width="16" height="16" /> **Exploitable**

Fix command injection vulnerability in Cowsay.java

**What is the issue?**
A command injection vulnerability (CWE-77) exists in `Cowsay.java` where user-controlled input from the `/cowsay` HTTP endpoint is concatenated directly into a shell command string and executed via `ProcessBuilder.command("bash", "-c", cmd)`. This allows an attacker to break out of the single-quote quoting and inject arbitrary shell metacharacters (`;`, `|`, `&`, `$()`, backticks, etc.). Any attacker reaching the endpoint can execute arbitrary OS commands with the privileges of the Java process.

**Why should it be fixed?**
This is a Critical severity (CVSS 10.0) vulnerability enabling full remote code execution, data exfiltration, lateral movement, and denial of service. An attacker can read sensitive files, drop reverse shells, or destroy data. It is flagged under OWASP Top 10 2021 (A03 Injection), PCI DSS v4.0, and CWE Top 25.

**How should it be fixed?**
In `src/main/java/com/scalesec/vulnado/Cowsay.java`, replace the shell-based invocation (`ProcessBuilder.command("bash", "-c", cmd)` with a concatenated string) with a direct argument list using `Arrays.asList("/usr/games/cowsay", input)` passed to `new ProcessBuilder(List<String>)`. This bypasses the shell entirely, calling `execve()` directly so that injection metacharacters in `input` are passed as literal data to the `cowsay` binary. Also remove the `System.out.println(cmd)` log line that previously disclosed user input in logs. In `src/test/java/com/scalesec/vulnado/CowsayTest.java`, add tests verifying that benign input works correctly and that seven injection attack patterns (single-quote escape, `$()`, backtick, semicolon, pipe, `&`, newline) are not executed, along with edge cases for empty and null input.



---
Use @Checkmarx to interact with Checkmarx PR Assistant. 
*Examples:*
`@Checkmarx how are you able to help me?`
`@Checkmarx rescan this PR`

<!--cx-integrations-metadata:{"remediationId":"847e9e72-1ac7-432c-9f1a-8493af1e54d7","resultId":"UgPnYpayjt0hj9lVb29r3m9+1aU="}-->